### PR TITLE
docs: update to vite7

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -37,7 +37,7 @@ The rolldown-powered version of Vite is currently available as a separate packag
 ```json
 {
   "dependencies": {
-    "vite": "^6.0.0" // [!code --]
+    "vite": "^7.0.0" // [!code --]
     "vite": "npm:rolldown-vite@latest" // [!code ++]
   }
 }


### PR DESCRIPTION
vite 7 is now the latest tag

